### PR TITLE
Integrate Firebase auth

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,21 +1,40 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
 import { useRouter } from 'expo-router';
+import * as Google from 'expo-auth-session/providers/google';
+import { GoogleAuthProvider } from 'firebase/auth';
 
 export default function LoginScreen() {
-  const { login } = useAuth();
+  const { login, loginWithCredential } = useAuth();
   const router = useRouter();
 
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const handleLogin = () => {
-    if (username === 'admin' && password === 'admin123') {
-      login(); // actualiza contexto
-      router.replace('/(tabs)/ninos'); // redirige
-    } else {
-      alert('Usuario o contraseña incorrectos');
+  const [request, response, promptAsync] = Google.useAuthRequest({
+    expoClientId: '<YOUR_EXPO_CLIENT_ID>',
+    androidClientId: '<YOUR_ANDROID_CLIENT_ID>',
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token } = response.authentication || {};
+      if (id_token) {
+        const credential = GoogleAuthProvider.credential(id_token);
+        loginWithCredential(credential).then(() => {
+          router.replace('/(tabs)/ninos');
+        });
+      }
+    }
+  }, [response]);
+
+  const handleLogin = async () => {
+    try {
+      await login(email, password);
+      router.replace('/(tabs)/ninos');
+    } catch (e: any) {
+      alert(e.message);
     }
   };
 
@@ -24,9 +43,9 @@ export default function LoginScreen() {
       <Text style={styles.title}>Iniciar sesión</Text>
       <TextInput
         style={styles.input}
-        placeholder="Usuario"
-        value={username}
-        onChangeText={setUsername}
+        placeholder="Correo electrónico"
+        value={email}
+        onChangeText={setEmail}
       />
       <TextInput
         style={styles.input}
@@ -36,6 +55,15 @@ export default function LoginScreen() {
         onChangeText={setPassword}
       />
       <Button title="Iniciar sesión" onPress={handleLogin} />
+      <Button
+        title="Iniciar con Google"
+        onPress={() => promptAsync()}
+        disabled={!request}
+      />
+      <Button
+        title="Crear cuenta"
+        onPress={() => router.push('/(auth)/signup')}
+      />
     </View>
   );
 }

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useAuth } from '../../contexts/AuthContext';
+import { useRouter } from 'expo-router';
+
+export default function SignupScreen() {
+  const { register } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSignup = async () => {
+    try {
+      await register(email, password);
+      router.replace('/(tabs)/ninos');
+    } catch (e: any) {
+      alert(e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Crear cuenta</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Correo electrónico"
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Contraseña"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+      <Button title="Registrarse" onPress={handleSignup} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 16,
+  },
+  input: {
+    width: '100%',
+    height: 40,
+    marginBottom: 12,
+    paddingLeft: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+  },
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,9 +2,9 @@ import { Slot } from 'expo-router';
 import { AuthProvider, useAuth } from '../contexts/AuthContext';
 
 function RootLayoutNav() {
-  const { isLoggedIn } = useAuth();
+  const { user } = useAuth();
 
-  if (!isLoggedIn) {
+  if (!user) {
     return <Slot name="(auth)" />;
   }
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,9 +2,9 @@ import { Redirect } from 'expo-router';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function Index() {
-  const { isLoggedIn } = useAuth();
+  const { user } = useAuth();
 
-  if (isLoggedIn) {
+  if (user) {
     return <Redirect href="/(tabs)/ninos" />;
   } else {
     return <Redirect href="/(auth)/login" />;

--- a/firebaseConfig.ts
+++ b/firebaseConfig.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getAuth } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: "AIzaSyCDLfOC8WG1JBKUXYTNLgX7BYrweC6MP3A",
@@ -11,3 +12,4 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- connect Firebase auth in firebaseConfig
- create auth context using Firebase
- support email login, Google login and registration
- add signup screen
- update routing for new auth state

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'firebase/app')*

------
https://chatgpt.com/codex/tasks/task_b_686db02a0dac832a80d1092cffd18676